### PR TITLE
Reshuffle-base-connector: handle method is used only in HTTPConnector…

### DIFF
--- a/src/Connector.ts
+++ b/src/Connector.ts
@@ -25,12 +25,6 @@ class Connector<OptionsType = any> {
   stop() {
     throw new Error('stop function needs to be implemented in your connector implementation')
   }
-
-  async handle(...args: any[]) {
-    throw new Error('handle function needs to be implemented in your connector implementation')
-
-    return false
-  }
 }
 
 export default Connector


### PR DESCRIPTION
… so it doesn't make sense to have it part of the abstract connector class